### PR TITLE
Changes in Container setup scripts to correct build errors when running on Jetson Orin devices under Jetpack 6.2.1

### DIFF
--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -1,21 +1,23 @@
 # Use the base TensorRT image
 FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
 
-WORKDIR /usr/src
+# Define the PyTorch precompiled wheel and its expected SHA256 hash as build arguments
+ARG TORCH_WHEEL=torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl
+ARG TORCH_WHEEL_SHA256=6f75fd2d2ef840ede1a90dbcf40a5458214bee26cc803fa510cda2e8978d972a
 
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
-    curl gnupg2 ffmpeg git && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-cuda.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/nvidia-cuda.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list && \
-    apt-get update && apt-get install -y \
+    curl gnupg2 ffmpeg git \
+    && curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | apt-key add - \
+    && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list \
+    && apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \
-    && git clone --recursive https://github.com/JonahMMay/wyoming-whisper-trt \
     && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
-    && wget -nv https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl \
-    && pip install --no-cache-dir torch-2.5.0a0+872d972e41*.whl \
+    && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
+    && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \
+    && pip install --no-cache-dir "./${TORCH_WHEEL}" \
     && pip install --upgrade pip setuptools wheel "numpy<2" packaging \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -1,5 +1,5 @@
 # Use the base TensorRT image
-FROM nvcr.io/nvidia/tensorrt:26.02-py3-igpu
+FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
 
 WORKDIR /usr/src
 
@@ -8,9 +8,11 @@ RUN apt-get update && apt-get install -y \
     python3-venv \
     ffmpeg \
     git \
-    && git clone --recursive https://github.com/JonahMMay/wyoming-whisper-trt \
+    && git clone --recursive https://github.com/Srafington/wyoming-whisper-trt \
     && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
+    && wget -nv https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl \
+    && pip3 install --no-cache-dir torch-2.5.0a0+872d972e41*.whl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -5,14 +5,18 @@ WORKDIR /usr/src
 
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
-    python3-venv python3-pip\
-    ffmpeg \
-    git \
+    curl gnupg2 ffmpeg git && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | apt-key add - && \
+    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list && \
+    apt-get update && apt-get install -y \
+    python3-venv python3-pip libopenblas-dev \
+    libcusparselt0 libcusparselt-dev \
     && git clone --recursive https://github.com/Srafington/wyoming-whisper-trt \
     && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
     && wget -nv https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl \
     && pip install --no-cache-dir torch-2.5.0a0+872d972e41*.whl \
+    && pip install --upgrade pip setuptools wheel "numpy<2" packaging \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -5,6 +5,9 @@ FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0
 ARG TORCH_WHEEL=torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl
 ARG TORCH_WHEEL_SHA256=6f75fd2d2ef840ede1a90dbcf40a5458214bee26cc803fa510cda2e8978d972a
 
+WORKDIR /usr/src/wyoming-whisper-trt
+COPY . /usr/src/wyoming-whisper-trt
+
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
     curl gnupg2 ffmpeg git \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -6,7 +6,7 @@ ARG TORCH_WHEEL=torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarc
 ARG TORCH_WHEEL_SHA256=6f75fd2d2ef840ede1a90dbcf40a5458214bee26cc803fa510cda2e8978d972a
 
 WORKDIR /usr/src/wyoming-whisper-trt
-COPY . /usr/src/wyoming-whisper-trt
+COPY . ./
 
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \
-    && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
     && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
     && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -6,8 +6,8 @@ WORKDIR /usr/src
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
     curl gnupg2 ffmpeg git && \
-    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list && \
+    curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-cuda.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia-cuda.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list && \
     apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -11,8 +11,11 @@ COPY . ./
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
     curl gnupg2 ffmpeg git \
-    && curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub | apt-key add - \
-    && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" > /etc/apt/sources.list.d/cuda-sbsa.list \
+    && install -d -m 0755 /usr/share/keyrings \
+    && curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub \
+         | gpg --dearmor -o /usr/share/keyrings/nvidia-cuda.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nvidia-cuda.gpg] https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/ /" \
+         > /etc/apt/sources.list.d/cuda-sbsa.list \
     && apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \
-    && git clone --recursive https://github.com/Srafington/wyoming-whisper-trt \
+    && git clone --recursive https://github.com/JonahMMay/wyoming-whisper-trt \
     && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
     && wget -nv https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \
+    && git submodule update --init --recursive \
     && chmod +x ./script/setup \
     && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
     && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \

--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -5,14 +5,14 @@ WORKDIR /usr/src
 
 # Update and install python3-venv, clone the repository, and run the setup script
 RUN apt-get update && apt-get install -y \
-    python3-venv \
+    python3-venv python3-pip\
     ffmpeg \
     git \
     && git clone --recursive https://github.com/Srafington/wyoming-whisper-trt \
     && cd wyoming-whisper-trt \
     && chmod +x ./script/setup \
     && wget -nv https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl \
-    && pip3 install --no-cache-dir torch-2.5.0a0+872d972e41*.whl \
+    && pip install --no-cache-dir torch-2.5.0a0+872d972e41*.whl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/docker-compose-github-igpu.yaml
+++ b/docker-compose-github-igpu.yaml
@@ -1,8 +1,9 @@
 services:
   wyoming-whisper-trt:
-    context: .
-    build: Dockerfile.igpu
-    container_name: wyoming-whisper-trt
+    build: 
+      context: .
+      dockerfile: Dockerfile.igpu
+    container_name: wyoming-whisper-trt-test
     ports:
       - 10300:10300
     restart: unless-stopped
@@ -18,5 +19,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-    network_mode: host
+      NVIDIA_EMBEDED: True
     runtime: nvidia

--- a/docker-compose-github-igpu.yaml
+++ b/docker-compose-github-igpu.yaml
@@ -19,5 +19,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      NVIDIA_EMBEDED: "True"
+      NVIDIA_EMBEDED: "true"
     runtime: nvidia

--- a/docker-compose-github-igpu.yaml
+++ b/docker-compose-github-igpu.yaml
@@ -3,7 +3,7 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile.igpu
-    container_name: wyoming-whisper-trt-test
+    container_name: wyoming-whisper-trt
     ports:
       - 10300:10300
     restart: unless-stopped
@@ -19,5 +19,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      NVIDIA_EMBEDED: True
+      NVIDIA_EMBEDED: "True"
     runtime: nvidia

--- a/docker-compose-github-igpu.yaml
+++ b/docker-compose-github-igpu.yaml
@@ -19,5 +19,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      NVIDIA_EMBEDED: "true"
+      NVIDIA_EMBEDDED: "true"
     runtime: nvidia

--- a/docker-compose-igpu.yaml
+++ b/docker-compose-igpu.yaml
@@ -3,6 +3,8 @@ services:
     image: captnspdr/wyoming-whisper-trt:latest-igpu
     container_name: wyoming-whisper-trt
     restart: unless-stopped
+    ports:
+      - 10300:10300
     environment:
       MODEL:      "${MODEL:-base}"
       LANGUAGE:   "${LANGUAGE:-auto}"
@@ -15,5 +17,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-    network_mode: host
+      NVIDIA_EMBEDED: True
     runtime: nvidia

--- a/docker-compose-igpu.yaml
+++ b/docker-compose-igpu.yaml
@@ -3,8 +3,6 @@ services:
     image: captnspdr/wyoming-whisper-trt:latest-igpu
     container_name: wyoming-whisper-trt
     restart: unless-stopped
-    ports:
-      - 10300:10300
     environment:
       MODEL:      "${MODEL:-base}"
       LANGUAGE:   "${LANGUAGE:-auto}"
@@ -17,5 +15,5 @@ services:
       DEBUG:      "${DEBUG:-false}"
       NVIDIA_VISIBLE_DEVICES:     all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      NVIDIA_EMBEDED: True
+    network_mode: host
     runtime: nvidia

--- a/run.sh
+++ b/run.sh
@@ -10,12 +10,13 @@ if [ ! -d ".venv" ]; then
     chmod +x script/setup
     setup_args=()
     if [ "${NVIDIA_EMBEDDED:-false}" = "true" ]; then
+    echo "NVIDIA_EMBEDDED is true. Adjusting setup for embedded environment..."
     # Remove tensorrt and torch from requirements.txt if NVIDIA_EMBEDDED is true
     # This is necessary because the torch and tensorrt packages installed on NVIDIA embedded devices are not compatible 
     # with the versions specified in requirements.txt, and attempting to install them will cause conflicts and break the setup process.
         sed -i '/tensorrt/d;/torch/d' requirements.txt
     # Enable system site packages so VENV can access TensorRT and PyTorch installed on the system
-       setup_args+=(--system_site_packages)
+        setup_args+=(--system_site_packages)
     fi
     ./script/setup "${setup_args[@]}"
 

--- a/run.sh
+++ b/run.sh
@@ -15,9 +15,9 @@ if [ ! -d ".venv" ]; then
     # with the versions specified in requirements.txt, and attempting to install them will cause conflicts and break the setup process.
         sed -i '/tensorrt/d;/torch/d' requirements.txt
     # Enable system site packages so VENV can access TensorRT and PyTorch installed on the system
-+       setup_args+=(--system_site_packages)
+       setup_args+=(--system_site_packages)
     fi
-+    ./script/setup "${setup_args[@]}"
+    ./script/setup "${setup_args[@]}"
 
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,14 @@ cd /usr/src/wyoming-whisper-trt
 if [ ! -d ".venv" ]; then
     echo "Virtual environment (.venv) not found. Running setup..."
     chmod +x script/setup
-    ./script/setup --system_site_packages ${NVIDIA_EMBEDDED:-False}
+    if [ "${NVIDIA_EMBEDDED}" = "true" ]; then
+    # Remove tensorrt and torch from requirements.txt if NVIDIA_EMBEDDED is true
+    # This is necessary because the torch and tensorrt packages installed on NVIDIA embedded devices are not compatible 
+    # with the versions specified in requirements.txt, and attempting to install them will cause conflicts and break the setup process.
+        sed -i '/tensorrt/d;/torch/d' requirements.txt
+    fi
+    python ./script/setup ${NVIDIA_EMBEDDED:+--system_site_packages}
+
 fi
 
 # Activate the Python virtual environment

--- a/run.sh
+++ b/run.sh
@@ -8,13 +8,16 @@ cd /usr/src/wyoming-whisper-trt
 if [ ! -d ".venv" ]; then
     echo "Virtual environment (.venv) not found. Running setup..."
     chmod +x script/setup
-    if [ "${NVIDIA_EMBEDDED}" = "true" ]; then
+    setup_args=()
+    if [ "${NVIDIA_EMBEDDED:-false}" = "true" ]; then
     # Remove tensorrt and torch from requirements.txt if NVIDIA_EMBEDDED is true
     # This is necessary because the torch and tensorrt packages installed on NVIDIA embedded devices are not compatible 
     # with the versions specified in requirements.txt, and attempting to install them will cause conflicts and break the setup process.
         sed -i '/tensorrt/d;/torch/d' requirements.txt
+    # Enable system site packages so VENV can access TensorRT and PyTorch installed on the system
++       setup_args+=(--system_site_packages)
     fi
-    python ./script/setup ${NVIDIA_EMBEDDED:+--system_site_packages}
++    ./script/setup "${setup_args[@]}"
 
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ cd /usr/src/wyoming-whisper-trt
 if [ ! -d ".venv" ]; then
     echo "Virtual environment (.venv) not found. Running setup..."
     chmod +x script/setup
-    ./script/setup
+    ./script/setup --system_site_packages ${NVIDIA_EMBEDDED:-False}
 fi
 
 # Activate the Python virtual environment

--- a/script/setup
+++ b/script/setup
@@ -12,10 +12,12 @@ _TORCH2TRT_DIR = _PROGRAM_DIR / "torch2trt"  # Update this path if torch2trt is 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dev", action="store_true", help="Install dev requirements")
-parser.add_argument("--system_site_packages", type=bool, help="Include system site packages in the virtual environment", default=False)
+parser.add_argument("--system_site_packages", action="store_true", help="Include system site packages in the virtual environment", default=False)
 args = parser.parse_args()
 
 # Create virtual environment
+if args.system_site_packages:
+    print("Creating virtual environment with access to system site packages...")
 builder = venv.EnvBuilder(with_pip=True, system_site_packages=args.system_site_packages)
 context = builder.ensure_directories(_VENV_DIR)
 builder.create(_VENV_DIR)

--- a/script/setup
+++ b/script/setup
@@ -12,10 +12,11 @@ _TORCH2TRT_DIR = _PROGRAM_DIR / "torch2trt"  # Update this path if torch2trt is 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dev", action="store_true", help="Install dev requirements")
+parser.add_argument("--system_site_packages", action="store_true", help="Include system site packages in the virtual environment", default=False)
 args = parser.parse_args()
 
 # Create virtual environment
-builder = venv.EnvBuilder(with_pip=True)
+builder = venv.EnvBuilder(with_pip=True, system_site_packages=args.system_site_packages)
 context = builder.ensure_directories(_VENV_DIR)
 builder.create(_VENV_DIR)
 

--- a/script/setup
+++ b/script/setup
@@ -12,7 +12,7 @@ _TORCH2TRT_DIR = _PROGRAM_DIR / "torch2trt"  # Update this path if torch2trt is 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dev", action="store_true", help="Install dev requirements")
-parser.add_argument("--system_site_packages", action="store_true", help="Include system site packages in the virtual environment", default=False)
+parser.add_argument("--system_site_packages", type=bool, help="Include system site packages in the virtual environment", default=False)
 args = parser.parse_args()
 
 # Create virtual environment


### PR DESCRIPTION
This PR contains a proposed set of changes that allow the Docker container intended for Jetson Orin devices to build successfully. This was tested against real hardware using a Jetson Orin Nano Super (8GB) running Jetpack 6.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated base image and system packages for NVIDIA Jetson / embedded GPU environments.
  * Expanded native libraries and CUDA repo setup for SBSA/Ubuntu 22.04 targets.
  * Simplified container build context handling and build configuration.

* **New Features**
  * Added pinned PyTorch wheel installation with SHA256 verification.
  * Exposed an embedded-mode flag in container config and removed host networking.
  * Added option to create the virtual environment with system site packages; runtime bootstrap respects embedded mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->