### PR TITLE
Suppress Whisper silence hallucinations (e.g. www.mooji.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,30 @@ Other GPU/TensorRT combinations may behave differently — run
 Guaranteed quantization would require explicit Q/DQ (e.g. via
 nvidia-modelopt), which only pays off on `medium`/`large` encoders.
 
+#### Silence hallucination suppression
+
+Fed audio with no real speech, Whisper reliably invents plausible-looking
+text — `www.mooji.org`, `Thank you for watching`, subtitle credits, and the
+like — pulled from its training data. Greedy decoding never selects the
+model's `<|nospeech|>` token (a real token always outscores it), so without a
+guard those phantom transcripts flow straight through to Home Assistant.
+
+Two gates suppress them:
+
+- **No-speech gate** (`--no-speech-threshold`, env `NO_SPEECH_THRESHOLD`,
+  default `0.6`): drops a window whose `<|nospeech|>` probability at the first
+  decode position is at or above the threshold, exactly as upstream
+  `whisper.transcribe` does. This is the accurate check and is enabled by
+  default. Set it above `1.0` to disable.
+- **Energy gate** (`--silence-threshold`, env `SILENCE_THRESHOLD`, default
+  `0.0` = disabled): an optional cheap hard cutoff that skips transcription
+  entirely when the audio's normalized ([-1, 1]) RMS is below the threshold.
+  Useful as belt-and-suspenders, but can clip genuinely quiet speech, so it is
+  off unless you opt in (e.g. `0.005`).
+
+Both cause the server to emit an empty transcript, which Home Assistant
+handles as "nothing was said".
+
 ### Testing and Linting Tools
 
 This project uses modern Python development tools:

--- a/run.sh
+++ b/run.sh
@@ -45,4 +45,6 @@ python3 -m wyoming_whisper_trt \
     --decoder-mode "${DECODER_MODE:-kv}" \
     --device "${DEVICE:-cuda}" \
     --beam-size "${BEAM_SIZE:-5}" \
+    --no-speech-threshold "${NO_SPEECH_THRESHOLD:-0.6}" \
+    --silence-threshold "${SILENCE_THRESHOLD:-0.0}" \
     "$@"

--- a/tests/test_wyoming_whisper_trt.py
+++ b/tests/test_wyoming_whisper_trt.py
@@ -27,7 +27,7 @@ from wyoming.audio import AudioStart, AudioStop, wav_to_chunks
 from wyoming.event import async_read_event, async_write_event
 from wyoming.info import Describe, Info
 
-from wyoming_whisper_trt.handler import TARGET_RATE, wav_bytes_to_np_array
+from wyoming_whisper_trt.handler import TARGET_RATE, _rms, wav_bytes_to_np_array
 
 _CUDA_AVAILABLE = torch.cuda.is_available()
 
@@ -138,6 +138,37 @@ def test_wav_bytes_to_np_array_normalizes(channels: int, rate: int) -> None:
     assert audio.flags["C_CONTIGUOUS"]
     assert abs(audio.size - TARGET_RATE) <= 1  # resampled to ~1 s at 16 kHz
     assert audio.max() <= 1.0 and audio.min() >= -1.0
+
+
+def test_rms_of_silence_is_zero() -> None:
+    """Digital silence (and an empty array) must have zero RMS."""
+    assert _rms(np.zeros(16000, dtype=np.float32)) == 0.0
+    assert _rms(np.array([], dtype=np.float32)) == 0.0
+
+
+def test_rms_of_full_scale_square_wave_is_one() -> None:
+    """A full-scale ±1 signal has unit RMS; a quiet signal stays below a gate."""
+    square = np.tile([1.0, -1.0], 8000).astype(np.float32)
+    assert _rms(square) == pytest.approx(1.0)
+    assert _rms(np.full(16000, 0.001, dtype=np.float32)) < 0.01
+
+
+def test_is_no_speech_gate() -> None:
+    """The no-speech gate fires only above threshold and stays off when disabled."""
+    tensorrt = pytest.importorskip("tensorrt")  # noqa: F841  # model.py needs TRT
+    from whisper_trt.model import WhisperTRT
+
+    class _Tok:
+        no_speech = 2
+
+    # Logits over a tiny vocab; index 2 is the <|nospeech|> token.
+    high = torch.tensor([[[0.0, 0.0, 10.0, 0.0]]])  # softmax ~0.9995 on no_speech
+    low = torch.tensor([[[10.0, 0.0, 0.0, 0.0]]])  # near-zero on no_speech
+
+    gate = WhisperTRT._is_no_speech
+    assert gate(None, _Tok(), high, 0.6) is True
+    assert gate(None, _Tok(), low, 0.6) is False
+    assert gate(None, _Tok(), high, None) is False  # disabled
 
 
 @pytest.mark.asyncio

--- a/whisper_trt/_decoder.py
+++ b/whisper_trt/_decoder.py
@@ -37,6 +37,10 @@ class DecodeRequest:
     max_len: int
     audio_features: Tensor
     stream: bool
+    # When set, decode returns empty text if the probability of the
+    # ``<|nospeech|>`` token at the first decode position meets this threshold.
+    # ``None`` disables the check. See ``WhisperTRT._is_no_speech``.
+    no_speech_threshold: float | None = None
 
 
 @dataclass

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -437,11 +437,18 @@ class WhisperTRT(nn.Module):
         decode_start = time.perf_counter()
 
         last_token_id = -1
+        first_step = True
         for _ in range(request.cur_len, request.max_len):
             token_logits = self.logits(
                 request.out_tokens[:, : request.cur_len],
                 request.audio_features,
             )
+            if first_step:
+                first_step = False
+                if self._is_no_speech(
+                    tokenizer, token_logits, request.no_speech_threshold
+                ):
+                    return "", [], time.perf_counter() - decode_start
             # One GPU->CPU sync per token; reuse the int for the buffer write
             # and the stop check rather than reading the tensor back twice.
             last_token_id = int(token_logits.argmax(dim=-1)[0, -1].item())
@@ -480,6 +487,11 @@ class WhisperTRT(nn.Module):
         decode_start = time.perf_counter()
         decoder = cast(TextDecoderTRTKV, self.decoder)
         logits, self_kv, cross_kv = self._prime_cache(request)
+
+        # ``logits`` here predict the first generated token, so this is the
+        # position Whisper evaluates for no-speech (see _is_no_speech).
+        if self._is_no_speech(tokenizer, logits, request.no_speech_threshold):
+            return "", [], time.perf_counter() - decode_start
 
         last_token_id = -1
         while request.cur_len < request.max_len:
@@ -529,6 +541,7 @@ class WhisperTRT(nn.Module):
         language: str,
         stream: bool,
         initial_prompt: str | None,
+        no_speech_threshold: float | None = None,
     ) -> tuple[str, list[str], float]:
         """Decode a mel tensor into final text and optional transcript chunks."""
         max_len = self.dims.n_text_ctx + 1
@@ -549,6 +562,7 @@ class WhisperTRT(nn.Module):
                 max_len=max_len,
                 audio_features=audio_features,
                 stream=stream,
+                no_speech_threshold=no_speech_threshold,
             )
             return self._decode_sequence(tokenizer, request)
 
@@ -559,8 +573,14 @@ class WhisperTRT(nn.Module):
         language: str = "auto",
         stream: bool = False,
         initial_prompt: str | None = None,
+        no_speech_threshold: float | None = None,
     ) -> dict[str, Any]:
-        """Transcribe audio with optional chunk emissions and an initial prompt."""
+        """Transcribe audio with optional chunk emissions and an initial prompt.
+
+        When ``no_speech_threshold`` is set, a window the model judges to be
+        non-speech (``<|nospeech|>`` probability at or above the threshold)
+        returns empty text instead of a hallucinated transcript.
+        """
         start_time = time.perf_counter()
         audio_array = self._normalize_audio_input(audio)
         mel, load_time = self._audio_to_mel(audio_array)
@@ -569,6 +589,7 @@ class WhisperTRT(nn.Module):
             language,
             stream,
             initial_prompt,
+            no_speech_threshold,
         )
 
         self.stream.synchronize()
@@ -598,6 +619,31 @@ class WhisperTRT(nn.Module):
         if hasattr(tokenizer, "all_language_codes"):
             return list(tokenizer.all_language_codes)
         return ["en"]
+
+    def _is_no_speech(
+        self,
+        tokenizer: Tokenizer,
+        first_logits: Tensor,
+        threshold: float | None,
+    ) -> bool:
+        """Whether the audio is silence/non-speech per the ``<|nospeech|>`` token.
+
+        Whisper emits a dedicated ``<|nospeech|>`` token whose probability at the
+        first decode position estimates how likely the window contains no speech.
+        Greedy decoding never selects it (a real token always outscores it), so
+        on silence the model instead hallucinates plausible-looking text
+        ("www.mooji.org", "Thank you for watching", ...). Gating on this
+        probability — as upstream ``whisper.transcribe`` does — suppresses those
+        phantom transcripts. Returns ``False`` when the check is disabled
+        (``threshold is None``) or the tokenizer lacks the token.
+        """
+        if threshold is None:
+            return False
+        no_speech_id = getattr(tokenizer, "no_speech", None)
+        if no_speech_id is None:
+            return False
+        probs = torch.softmax(first_logits[0, -1, :].float(), dim=-1)
+        return float(probs[no_speech_id].item()) >= threshold
 
     def _decode_tokens(self, tokens: torch.Tensor) -> str:
         """Decode token tensor to clean text without internal control markers."""

--- a/whisper_trt/model.py
+++ b/whisper_trt/model.py
@@ -580,6 +580,24 @@ class WhisperTRT(nn.Module):
         When ``no_speech_threshold`` is set, a window the model judges to be
         non-speech (``<|nospeech|>`` probability at or above the threshold)
         returns empty text instead of a hallucinated transcript.
+
+        Args:
+            audio: Path to an audio file or numpy array containing audio data.
+            language: Language code for transcription (e.g., "en", "es") or
+                "auto" for automatic language detection. Defaults to "auto".
+            stream: If True, return intermediate transcription chunks in addition
+                to the final text. Defaults to False.
+            initial_prompt: Optional text to provide as context for the first
+                transcription window, which can improve accuracy. Defaults to None.
+            no_speech_threshold: Probability threshold (0.0-1.0) for suppressing
+                non-speech segments. Windows with ``<|nospeech|>`` probability at
+                or above this value return empty text. None disables this feature.
+                Defaults to None.
+
+        Returns:
+            A dictionary containing the transcription result with a "text" key
+            holding the final transcript. If stream=True, also includes a "chunks"
+            key with a list of intermediate transcription segments.
         """
         start_time = time.perf_counter()
         audio_array = self._normalize_audio_input(audio)

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -369,11 +369,9 @@ def _parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-async def main() -> None:
-    """Main entry point."""
-    args = _parse_args()
-
-    # Validate no-speech-threshold
+def _validate_args(args: argparse.Namespace) -> None:
+    """Validate numeric CLI arguments, exiting with an error on bad values."""
+    # no-speech-threshold: non-negative (values > 1.0 disable the gate)
     if math.isnan(args.no_speech_threshold):
         logger.error("Invalid --no-speech-threshold: NaN is not allowed.")
         sys.exit(1)
@@ -385,24 +383,30 @@ async def main() -> None:
         )
         sys.exit(1)
 
-    # Validate silence-threshold
+    # silence-threshold: a normalized RMS in [0.0, 1.0]
     if math.isnan(args.silence_threshold):
         logger.error("Invalid --silence-threshold: NaN is not allowed.")
         sys.exit(1)
-    if not (0.0 <= args.silence_threshold <= 1.0):
+    if not 0.0 <= args.silence_threshold <= 1.0:
         logger.error(
             "Invalid --silence-threshold value: %f. Must be in range [0.0, 1.0].",
             args.silence_threshold,
         )
         sys.exit(1)
 
-    # Validate max-workspace-mb (None means "auto", resolved below)
+    # max-workspace-mb (None means "auto", resolved later)
     if args.max_workspace_mb is not None and args.max_workspace_mb <= 0:
         logger.error(
             "Invalid --max-workspace-mb value: %d. Must be a positive integer.",
             args.max_workspace_mb,
         )
         sys.exit(1)
+
+
+async def main() -> None:
+    """Main entry point."""
+    args = _parse_args()
+    _validate_args(args)
 
     # Setup logging
     setup_logging(args.debug, args.log_format)

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -322,6 +322,27 @@ def _parse_args() -> argparse.Namespace:
         help="Enable partial transcription streaming",
     )
     parser.add_argument(
+        "--no-speech-threshold",
+        type=float,
+        default=0.6,
+        help=(
+            "Suppress silence hallucinations (e.g. 'www.mooji.org'): drop a "
+            "window whose '<|nospeech|>' probability is at or above this value "
+            "(0.0-1.0). Set to a value > 1 to disable. Default: 0.6."
+        ),
+    )
+    parser.add_argument(
+        "--silence-threshold",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional hard energy gate: skip transcription for audio whose "
+            "normalized ([-1, 1]) RMS is below this value, emitting an empty "
+            "transcript. 0.0 (default) disables it; the no-speech gate is the "
+            "accurate check."
+        ),
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable DEBUG level logging",
@@ -445,6 +466,8 @@ async def main() -> None:
             initial_prompt=args.initial_prompt,
             streaming=args.streaming,
             default_language=args.language,
+            no_speech_threshold=args.no_speech_threshold,
+            silence_rms_threshold=args.silence_threshold,
         ),
     )
 

--- a/wyoming_whisper_trt/__main__.py
+++ b/wyoming_whisper_trt/__main__.py
@@ -10,6 +10,7 @@ This script initializes the Whisper TRT model, sets up the server, and handles c
 import argparse
 import asyncio
 import logging
+import math
 import os
 import sys
 import time
@@ -371,6 +372,29 @@ def _parse_args() -> argparse.Namespace:
 async def main() -> None:
     """Main entry point."""
     args = _parse_args()
+
+    # Validate no-speech-threshold
+    if math.isnan(args.no_speech_threshold):
+        logger.error("Invalid --no-speech-threshold: NaN is not allowed.")
+        sys.exit(1)
+    if args.no_speech_threshold < 0.0:
+        logger.error(
+            "Invalid --no-speech-threshold value: %f. Must be non-negative "
+            "(values > 1.0 disable the feature).",
+            args.no_speech_threshold,
+        )
+        sys.exit(1)
+
+    # Validate silence-threshold
+    if math.isnan(args.silence_threshold):
+        logger.error("Invalid --silence-threshold: NaN is not allowed.")
+        sys.exit(1)
+    if not (0.0 <= args.silence_threshold <= 1.0):
+        logger.error(
+            "Invalid --silence-threshold value: %f. Must be in range [0.0, 1.0].",
+            args.silence_threshold,
+        )
+        sys.exit(1)
 
     # Validate max-workspace-mb (None means "auto", resolved below)
     if args.max_workspace_mb is not None and args.max_workspace_mb <= 0:

--- a/wyoming_whisper_trt/handler.py
+++ b/wyoming_whisper_trt/handler.py
@@ -74,6 +74,13 @@ def wav_bytes_to_np_array(wav_bytes: bytes) -> np.ndarray:
     return np.ascontiguousarray(audio, dtype=np.float32)
 
 
+def _rms(audio: np.ndarray) -> float:
+    """Root-mean-square amplitude of normalized ([-1, 1]) mono audio."""
+    if audio.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(audio, dtype=np.float64))))
+
+
 @dataclass
 class HandlerSettings:
     """Runtime settings for the event handler."""
@@ -81,6 +88,13 @@ class HandlerSettings:
     initial_prompt: str | None = None
     streaming: bool = False
     default_language: str | None = None
+    # Suppress Whisper's silence hallucinations (e.g. "www.mooji.org"). The
+    # no-speech gate drops a window whose ``<|nospeech|>`` probability meets
+    # this threshold; ``None`` disables it. The RMS gate short-circuits audio
+    # quieter than this normalized ([-1, 1]) root-mean-square before it ever
+    # reaches the model; ``0.0`` disables it.
+    no_speech_threshold: float | None = 0.6
+    silence_rms_threshold: float = 0.0
 
 
 @dataclass
@@ -197,6 +211,18 @@ class WhisperTrtEventHandler(AsyncEventHandler):
 
         wav_bytes = self._wav_buffer.getvalue()
         audio_np = wav_bytes_to_np_array(wav_bytes)
+
+        # Cheap energy gate: near-silent audio only ever produces Whisper
+        # hallucinations, so short-circuit it before touching the model. The
+        # no-speech gate inside transcribe() is the accurate check; this is an
+        # optional hard cutoff, disabled by default (threshold 0.0).
+        threshold = self._settings.silence_rms_threshold
+        if threshold > 0.0 and _rms(audio_np) < threshold:
+            logger.debug("Audio below silence RMS threshold; emitting empty transcript")
+            await self._emit_transcript("")
+            self._wav_buffer = io.BytesIO()
+            return
+
         loop = asyncio.get_event_loop()
         try:
             async with self.model_lock:
@@ -207,6 +233,7 @@ class WhisperTrtEventHandler(AsyncEventHandler):
                         self._language or "auto",
                         stream=False,
                         initial_prompt=prompt,
+                        no_speech_threshold=self._settings.no_speech_threshold,
                     ),
                 )
             final_text = result.get("text", "").strip()
@@ -219,10 +246,19 @@ class WhisperTrtEventHandler(AsyncEventHandler):
             self._wav_buffer = io.BytesIO()
             return
 
-        # for streaming clients: TranscriptStart → TranscriptChunk → Transcript → TranscriptStop
-        # for non-streaming clients: Transcript only
-        # (HA's wyoming/stt.py ignores streaming events and waits for Transcript)
+        await self._emit_transcript(final_text)
 
+        # reset for next utterance
+
+        self._wav_buffer = io.BytesIO()
+
+    async def _emit_transcript(self, final_text: str) -> None:
+        """Emit a completed transcript, matching the client's streaming mode.
+
+        For streaming clients: TranscriptStart → TranscriptChunk → Transcript →
+        TranscriptStop. For non-streaming clients: Transcript only. (HA's
+        wyoming/stt.py ignores the streaming events and waits for Transcript.)
+        """
         if self._settings.streaming:
             await self.write_event(TranscriptStart(language=self._language).event())
             if final_text:
@@ -231,10 +267,6 @@ class WhisperTrtEventHandler(AsyncEventHandler):
             await self.write_event(TranscriptStop().event())
         else:
             await self.write_event(Transcript(text=final_text).event())
-
-        # reset for next utterance
-
-        self._wav_buffer = io.BytesIO()
 
     async def _handle_transcribe(self, event: Event) -> None:
         # allow client to change language on the fly

--- a/wyoming_whisper_trt/handler.py
+++ b/wyoming_whisper_trt/handler.py
@@ -83,16 +83,28 @@ def _rms(audio: np.ndarray) -> float:
 
 @dataclass
 class HandlerSettings:
-    """Runtime settings for the event handler."""
+    """Runtime settings for the event handler.
+
+    Attributes:
+        initial_prompt: Optional text to provide as context for the first
+            transcription window. None means no initial prompt is provided.
+        streaming: If True, emit intermediate transcription chunks in addition
+            to the final text. Defaults to False.
+        default_language: Default language code for transcription (e.g., "en",
+            "es") or None for automatic language detection. Defaults to None.
+        no_speech_threshold: Probability threshold (0.0-1.0) for suppressing
+            Whisper's silence hallucinations (e.g. "www.mooji.org"). Drops a
+            window whose ``<|nospeech|>`` probability meets or exceeds this
+            threshold. None disables this feature. Defaults to 0.6.
+        silence_rms_threshold: RMS energy threshold for the hard silence gate.
+            Audio quieter than this normalized ([-1, 1]) root-mean-square value
+            is short-circuited before reaching the model, emitting empty text.
+            0.0 disables this feature. Defaults to 0.0.
+    """
 
     initial_prompt: str | None = None
     streaming: bool = False
     default_language: str | None = None
-    # Suppress Whisper's silence hallucinations (e.g. "www.mooji.org"). The
-    # no-speech gate drops a window whose ``<|nospeech|>`` probability meets
-    # this threshold; ``None`` disables it. The RMS gate short-circuits audio
-    # quieter than this normalized ([-1, 1]) root-mean-square before it ever
-    # reaches the model; ``0.0`` disables it.
     no_speech_threshold: float | None = 0.6
     silence_rms_threshold: float = 0.0
 


### PR DESCRIPTION
## Problem

Blank/silent utterances consistently surface in Home Assistant as **`www.mooji.org`** (and its cousins: *"Thank you for watching"*, subtitle credits, `♪♪♪`). These are Whisper **silence hallucinations** — plausible-looking text the model pulls from its training data when fed audio with no real speech.

The decode path here is pure greedy argmax with no guardrails: it never selects Whisper's `<|nospeech|>` token (a real token always outscores it) and has no `no_speech_threshold` / energy gate. The handler faithfully forwards whatever the model returns, so the phantom text goes straight to HA. It's deterministic — same silence → same phantom phrase — which is why it looks "consistent." Stock HA Whisper backends (faster-whisper) rarely show this because they apply exactly the no-speech gate added here.

## Changes

Two suppression gates, both emitting an **empty transcript** (HA treats it as "nothing was said"):

- **No-speech gate** (`--no-speech-threshold`, env `NO_SPEECH_THRESHOLD`, default `0.6`, **on**): reads the `<|nospeech|>` probability at the first decode position and short-circuits to empty text above the threshold — matching upstream `whisper.transcribe`. Threaded through `transcribe() → _decode_mel() → DecodeRequest` and checked in both the KV and simple decode paths. Uses logits already computed, so it's essentially free.
- **Energy/RMS gate** (`--silence-threshold`, env `SILENCE_THRESHOLD`, default `0.0` = **off**): optional cheap hard cutoff that skips transcription for near-silent audio before the model runs. Off by default since it can clip genuinely quiet speech; opt in with e.g. `0.005`.

Also: CLI flags + `run.sh` env vars, README section, and CPU-safe unit tests for `_rms` and `_is_no_speech`.

## Testing

- New unit tests (`_rms`, `_is_no_speech`) pass on CPU; ruff clean; no new mypy errors.
- The existing GPU end-to-end test is unaffected (default threshold doesn't touch real-speech transcription).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically suppresses hallucinated transcripts when fed non-speech audio.
  * Added a default-enabled no-speech probability threshold (configurable via command-line/env).
  * Added an optional silence/energy (RMS) gate to skip near-silent recordings (disabled by default).
  * Suppressed/empty results are emitted as an empty transcript (treated as “nothing was said”).
  * Exposes the no-speech threshold as an option for transcription.
* **Documentation**
  * Documented the suppression mechanisms and threshold behavior.
* **Tests**
  * Added unit tests covering audio RMS metrics and no-speech gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->