### PR TITLE
ci: drop redundant driver/docker/CUDA installs on self-hosted runner

### DIFF
--- a/.github/workflows/publish_container.yaml
+++ b/.github/workflows/publish_container.yaml
@@ -29,53 +29,13 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
 
-      - name: Install Nvidia Drivers
-        shell: bash
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y nvidia-open
-      
-      - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
-        with:
-          use-github-cache: false
-
-      - name: Install Docker and Buildx
-        shell: bash
-        run: |
-          # Add Docker's official GPG key:
-          sudo apt-get update
-          sudo apt-get install ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-          # Add the repository to Apt sources:
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
+      # GPU driver (nvidia runtime), Docker (dind sidecar) are provided by the
+      # self-hosted ARC runner; building the image doesn't need host CUDA/nvcc
+      # (CUDA lives in the Dockerfile base image), so no in-job installs needed.
       - name: Set up QEMU
         uses: docker/setup-qemu-action@f4e8deed0c3c26542279f4042c0e1d059cbf012d
         with:
           platforms: all
-
-      - name: Install Nvidia Container Toolkit
-        shell: bash
-        run: |
-          curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-          && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-            sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-          sudo apt-get update
-          sudo apt-get install -y nvidia-container-toolkit
-          sudo nvidia-ctk runtime configure --runtime=docker
-          sudo systemctl restart docker
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,38 +45,24 @@ jobs:
         with:
           submodules: recursive
 
-      # 2. Install GCC and G++
-      - name: Install GCC and G++
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install -y gcc g++
+      # gcc/g++, netcat-openbsd and virtualenv are baked into the custom runner
+      # image (local/gpu-runner), so no in-job apt/pip installs are needed.
 
-      # 3. Install Netcat (nc) for listening checks
-      - name: Install Netcat
-        shell: bash
-        run: |
-          sudo apt-get install -y netcat-openbsd
-
-      # 4. Setup Python environment
+      # Setup Python. RUNNER_TOOL_CACHE points at the persistent NFS cache on
+      # the runner, so 3.13 is downloaded once and restored instantly after.
       - name: Setup Python
         uses: actions/setup-python@28f2168f4d98ee0445e3c6321f6e6616c83dd5ec
         with:
           python-version: '3.13'  # Use a stable version
 
-      - name: Install Python venv
-        shell: bash
-        run: |
-          pip install virtualenv
-
-      # 5. Install CUDA Toolkit
-      # NOTE: the GPU driver is provided by the self-hosted runner's nvidia
-      # runtime (nvidia-smi already works), so no in-job driver install is
-      # needed. Cache the toolkit to avoid re-downloading it every run.
+      # Install CUDA Toolkit. The GPU driver comes from the runner's nvidia
+      # runtime; the toolkit installer is cached both in GitHub cache and the
+      # persistent runner tool cache, so runs after the first are fast.
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
         with:
           use-github-cache: true
+          use-local-cache: true
 
       # 6. Create and activate virtual environment
       - name: Setup Virtual Environment
@@ -95,9 +81,18 @@ jobs:
           # Define server URI for testing
           TEST_URI="tcp://127.0.0.1:8080"
 
-          # Define data and download directories
-          DATA_DIR="./data"
-          DOWNLOAD_DIR="./download"
+          # Data (built TRT engine) and model download dirs. Point them at the
+          # persistent runner cache when available so the expensive TRT engine
+          # build + model download are reused across runs; fall back to local
+          # dirs on runners without the cache mount.
+          if [ -n "$RUNNER_CACHE" ]; then
+            DATA_DIR="$RUNNER_CACHE/whisper/data"
+            DOWNLOAD_DIR="$RUNNER_CACHE/whisper/download"
+          else
+            DATA_DIR="./data"
+            DOWNLOAD_DIR="./download"
+          fi
+          echo "Using DATA_DIR=$DATA_DIR DOWNLOAD_DIR=$DOWNLOAD_DIR"
 
           # Create necessary directories
           mkdir -p $DATA_DIR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,18 +70,13 @@ jobs:
           pip install virtualenv
 
       # 5. Install CUDA Toolkit
-      - name: Install Nvidia Drivers
-        shell: bash
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-          sudo dpkg -i cuda-keyring_1.1-1_all.deb
-          sudo apt-get update
-          sudo apt-get install -y nvidia-open
-      
+      # NOTE: the GPU driver is provided by the self-hosted runner's nvidia
+      # runtime (nvidia-smi already works), so no in-job driver install is
+      # needed. Cache the toolkit to avoid re-downloading it every run.
       - name: Install CUDA Toolkit
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76
         with:
-          use-github-cache: false
+          use-github-cache: true
 
       # 6. Create and activate virtual environment
       - name: Setup Virtual Environment
@@ -172,18 +167,3 @@ jobs:
           name: server-logs
           path: server.log
         if: always()  # This ensures the step runs even if previous steps fail
-        
-      # 9. CUDA driver/library mismatch auto-fix (only on failure)
-      - name: CUDA Driver/Library Mismatch Auto-Fix
-        if: ${{ failure() }}
-        shell: bash
-        run: |
-          echo "Scanning server.log for NVML initialization failure..."
-          if grep -Fq "Failed to initialize NVML: Driver/library version mismatch" server.log; then
-            echo "CUDA driver/library version mismatch detected—upgrading system and rebooting."
-            sudo apt update
-            sudo apt upgrade -y
-            sudo reboot
-          else
-            echo "No NVML mismatch found; skipping auto-fix."
-          fi


### PR DESCRIPTION
The self-hosted ARC runner now provides the GPU driver (nvidia runtime) and Docker (dind sidecar). This removes the per-run installs of the NVIDIA driver, Docker, and nvidia-container-toolkit, plus the in-container 'systemctl restart docker' and 'sudo reboot' steps (harmful in a container). CUDA toolkit is kept (nvcc still needed) but now cached. Should cut several minutes off each self-hosted run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined container publishing and Linux test workflows by using GPU, CUDA, Docker, and Buildx components provided by the self-hosted runner.
  * Improved CUDA toolkit setup by leveraging the GitHub cache.
  * Removed automatic driver repair and reboot steps after test runs.
  * Continued support for cross-platform image builds through QEMU.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->