### PR TITLE
build: make apt resilient to stalled mirror fetches (retries + timeout)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,11 @@ COPY . /usr/src/wyoming-whisper-trt
 # CUDA/cuDNN wheels and tensorrt is a pip wheel, so the resulting venv is
 # self-contained w.r.t. CUDA/TensorRT — nothing links back to the base's
 # /usr/local/cuda toolkit at runtime.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Make apt resilient to a stalled mirror connection: without a timeout apt can
+# hang indefinitely on a half-open fetch (observed wedging a multi-hour build);
+# retries + a 30s timeout make it fail fast and recover instead.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
+    && apt-get update && apt-get install -y --no-install-recommends \
         python3-venv \
         git \
     && chmod +x ./script/setup \
@@ -43,7 +47,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ===========================================================================
 FROM ubuntu:24.04 AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
+    && apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         python3.12 \
         ffmpeg \


### PR DESCRIPTION
## Problem
The 1.2.0 `Publish Docker Images` run wedged for ~1.5h on the runtime-stage `apt-get update` (`#16 [linux/amd64 runtime 2/5]`). Nothing published (multi-arch manifest push waits for all legs), so Docker Hub stayed on 1.1.6.

## Root cause (verified on the runner, not assumed)
- **Not** IPv6/DNS/arch: fresh `apt-get update` in the same dind sandbox succeeds on amd64 (~3s) and emulated arm64 (~8s), over both IP stacks; disk 59 GB free.
- The actual hang was a single wedged `apt-get` (PID 1103) with all its `http`/`gpgv`/`store` method processes `State: S`, **0 CPU for 100+ min** — a mirror connection stalled mid-fetch and apt has **no default timeout**, so it waits forever and BuildKit waits on it.

## Fix
Add an apt.conf drop-in to the builder + runtime apt steps:
```
Acquire::Retries "3";
Acquire::http::Timeout "30";
Acquire::https::Timeout "30";
```
A stalled fetch now fails in 30s and retries instead of hanging. (Kept arm64; ForceIPv4 was ruled out.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)