### PR TITLE
fix(igpu): drop broken git submodule update + harden apt

### DIFF
--- a/Dockerfile.igpu
+++ b/Dockerfile.igpu
@@ -8,8 +8,11 @@ ARG TORCH_WHEEL_SHA256=6f75fd2d2ef840ede1a90dbcf40a5458214bee26cc803fa510cda2e89
 WORKDIR /usr/src/wyoming-whisper-trt
 COPY . ./
 
-# Update and install python3-venv, clone the repository, and run the setup script
-RUN apt-get update && apt-get install -y \
+# Update and install python3-venv, clone the repository, and run the setup script.
+# Make apt resilient to a stalled mirror connection (no timeout => can hang the
+# build for hours); retries + a 30s timeout make it fail fast and recover.
+RUN printf 'Acquire::Retries "3";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/99network-resilience \
+    && apt-get update && apt-get install -y \
     curl gnupg2 ffmpeg git \
     && install -d -m 0755 /usr/share/keyrings \
     && curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/3bf863cc.pub \
@@ -19,7 +22,6 @@ RUN apt-get update && apt-get install -y \
     && apt-get update && apt-get install -y \
     python3-venv python3-pip libopenblas-dev \
     libcusparselt0 libcusparselt-dev \
-    && git submodule update --init --recursive \
     && chmod +x ./script/setup \
     && curl -fLo "${TORCH_WHEEL}" "https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/${TORCH_WHEEL}" \
     && echo "${TORCH_WHEEL_SHA256}  ${TORCH_WHEEL}" | sha256sum -c - \


### PR DESCRIPTION
## Problem
The 1.2.0 publish's **ARM64 iGPU (Jetson)** step failed:
```
Dockerfile.igpu:12  RUN … && git submodule update --init --recursive …
fatal: not a git repository (or any of the parent directories): .git
exit code: 128
```
(The dGPU image built + pushed fine — this only blocked the Jetson/iGPU tag, which is why `latest-igpu` is stuck at 1.1.6.)

## Cause
The build context has no `.git` — source arrives via `COPY . ./` from the workflow's `submodules: recursive` checkout, not a clone. So `git submodule update` has no repo to operate on. The submodule (torch2trt) is **already present** from the recursive checkout — the working dGPU `Dockerfile` relies on exactly that and never runs a submodule update.

## Fix
- Drop the redundant, broken `git submodule update --init --recursive`.
- Add the same apt retries+timeout hardening (this file was missed by the main-image PR) so a stalled mirror fetch can't hang the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image build reliability by adding retry handling and longer network timeouts for system package installation.
  * Prevented unnecessary submodule initialization during image builds, helping streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->